### PR TITLE
Clear pipeline cache weekly and update Windows to 21H2

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -1,0 +1,22 @@
+name: Weekly cache-clear
+
+on:
+  schedule:
+    - cron: "0 1 * * SUN" # At 01:00 on Sunday
+  workflow_dispatch:
+  
+jobs:
+  delete-cache:
+    runs-on: [self-hosted, linux]
+    steps:
+      - uses: actions/checkout@v2
+      
+      - name: Delete cached iso files
+        run: rm -rf /usr/share/runner-dependencies/packer_cache/*
+        
+      - name: Delete any remaining VM artifacts
+        run: rm -rf /usr/share/runner-dependencies/virtual_machines/*
+        
+      - name: Delete any remaining venv artifacts
+        run: rm -rf /usr/share/runner-dependencies/socbed_env || true
+        

--- a/provisioning/packer/client.json
+++ b/provisioning/packer/client.json
@@ -115,8 +115,8 @@
   ],
   "variables": {
     "floppy_files_path": "./floppy_files/",
-    "iso_checksum": "e47890d75a6e18211f6790d9d4864a17",
-    "iso_url": "/usr/share/runner-dependencies/Win10.iso",
+    "iso_checksum": "823c3cb59ff0fd43272f12bb2e3a089d",
+    "iso_url": "/usr/share/runner-dependencies/windows_isos/Win10_21H2_English_x64.iso",
     "vm_description": "SOCBED: Client",
     "vm_version": "fresh",
     "vm_output": "./exports/client"

--- a/tools/build_attacker
+++ b/tools/build_attacker
@@ -8,7 +8,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/attacker' attacker.json
 else
 packer build -force attacker.json

--- a/tools/build_attacker
+++ b/tools/build_attacker
@@ -9,7 +9,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/attacker' attacker.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/attacker' attacker.json
 else
 packer build -force attacker.json
 fi

--- a/tools/build_client
+++ b/tools/build_client
@@ -10,7 +10,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/client' client.json
 else
 packer build -force client.json

--- a/tools/build_client
+++ b/tools/build_client
@@ -11,7 +11,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/client' client.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/client' client.json
 else
 packer build -force client.json
 fi

--- a/tools/build_companyrouter
+++ b/tools/build_companyrouter
@@ -9,7 +9,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/companyrouter' companyrouter.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/companyrouter' companyrouter.json
 else
 packer build -force companyrouter.json
 fi

--- a/tools/build_companyrouter
+++ b/tools/build_companyrouter
@@ -8,7 +8,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/companyrouter' companyrouter.json
 else
 packer build -force companyrouter.json

--- a/tools/build_dmzserver
+++ b/tools/build_dmzserver
@@ -11,7 +11,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/dmzserver' dmzserver.json
 else
 packer build -force dmzserver.json

--- a/tools/build_dmzserver
+++ b/tools/build_dmzserver
@@ -12,7 +12,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/dmzserver' dmzserver.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/dmzserver' dmzserver.json
 else
 packer build -force dmzserver.json
 fi

--- a/tools/build_internalserver
+++ b/tools/build_internalserver
@@ -14,7 +14,7 @@ sleep 180
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/internalserver' internalserver.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/internalserver' internalserver.json
 else
 packer build -force internalserver.json
 fi

--- a/tools/build_internalserver
+++ b/tools/build_internalserver
@@ -13,7 +13,7 @@ echo "Sleep for 180 seconds to ensure the elasticsearch-service (Log Server) is 
 sleep 180
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/internalserver' internalserver.json
 else
 packer build -force internalserver.json

--- a/tools/build_internetrouter
+++ b/tools/build_internetrouter
@@ -7,7 +7,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/internetrouter' internetrouter.json
 else
 packer build -force internetrouter.json

--- a/tools/build_internetrouter
+++ b/tools/build_internetrouter
@@ -8,7 +8,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/internetrouter' internetrouter.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/internetrouter' internetrouter.json
 else
 packer build -force internetrouter.json
 fi

--- a/tools/build_logserver
+++ b/tools/build_logserver
@@ -10,7 +10,7 @@ cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
 export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
-packer build -force -var 'vm_output=/usr/share/runner-dependencies/logserver' logserver.json
+packer build -force -var 'vm_output=/usr/share/runner-dependencies/virtual_machines/logserver' logserver.json
 else
 packer build -force logserver.json
 fi

--- a/tools/build_logserver
+++ b/tools/build_logserver
@@ -9,7 +9,7 @@ export ANSIBLE_HOST_KEY_CHECKING=False
 cd ./provisioning/packer/
 
 if [ -n "$1" ] && [ $1 == "runner" ]; then
-export PACKER_CACHE_DIR=/usr/share/runner-dependencies
+export PACKER_CACHE_DIR=/usr/share/runner-dependencies/packer_cache
 packer build -force -var 'vm_output=/usr/share/runner-dependencies/logserver' logserver.json
 else
 packer build -force logserver.json


### PR DESCRIPTION
This changes three things:
- tidies up directory structure used by the runner
- adds a separate workflow for a weekly cache clear (can also be triggered manually)
- updates the Win10 version used by the client to 21H2