### PR TITLE
Rename "longtest" to "unstable"

### DIFF
--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -105,12 +105,12 @@ jobs:
       - name: Ensure all machines are powered off
         run: ./tools/cleanup_failed_session
       
-      - name: Run system tests ("not longtest")
+      - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: tox -- -m "systest and not longtest"
+          command: tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -100,12 +100,12 @@ jobs:
       - name: Ensure all machines are powered off
         run: ./tools/cleanup_failed_session
       
-      - name: Run system tests ("not longtest")
+      - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: tox -- -m "systest and not longtest"
+          command: tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/README.md
+++ b/README.md
@@ -97,12 +97,15 @@ Run all unit tests from the repository root directory:
 tox -- -m "not systest"
 ```
 
-If they succeed, run the essential system tests:
-```sh
-tox -- -m "systest and not longtest"
-```
+If they succeed, run all stable system tests:
 
-Attention: System tests will start and stop the virtual machines several times and  can take a while to complete!
+Attention: System tests will start and stop the virtual machines several times and can take a while to complete!
+Do not use SOCBED VMs or apps (`attackconsole`, `vmconsole`) while system tests are running.
+
+```sh
+tox -- -m "systest and not unstable"
+```
+(Unstable systests sometimes fail despite correct SOCBED functionality, we're working on it.)
 
 ## Example
 

--- a/src/systests/test_logging.py
+++ b/src/systests/test_logging.py
@@ -34,7 +34,7 @@ from vmcontrol.sessionhandler import SessionHandler
 from vmcontrol.vmmcontroller import VBoxController
 
 MAX_RUNTIME = 10 * 60  # Ten minutes
-pytestmark = [pytest.mark.systest, pytest.mark.longtest]
+pytestmark = [pytest.mark.systest, pytest.mark.unstable]
 
 @pytest.fixture(scope="module")
 def session():

--- a/src/systests/test_ntp_active.py
+++ b/src/systests/test_ntp_active.py
@@ -28,7 +28,7 @@ from systests.test_ntp_passive import Time, MachineProperties, machines_using_nt
 from vmcontrol.sessionhandler import SessionHandler
 from vmcontrol.vmmcontroller import VBoxController
 
-pytestmark = [pytest.mark.systest, pytest.mark.longtest]
+pytestmark = [pytest.mark.systest, pytest.mark.unstable]
 
 
 @pytest.fixture(scope="module")

--- a/src/systests/test_ntp_passive.py
+++ b/src/systests/test_ntp_passive.py
@@ -29,7 +29,7 @@ from attacks.ssh import BREACHSSHClient, SSHTargets
 from vmcontrol.sessionhandler import SessionHandler
 from vmcontrol.vmmcontroller import VBoxController
 
-pytestmark = [pytest.mark.systest, pytest.mark.longtest]
+pytestmark = [pytest.mark.systest, pytest.mark.unstable]
 
 
 @pytest.fixture(scope="module")

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,8 @@
 # Usage examples:
-#   tox                      # Run all tests
-#   tox -- -m "not systest"  # Run unit tests only
-#   tox -- -m "systest"      # Run system tests only
-#   tox -- -m "not longtest" # Run all except very long tests
+#   tox                                   # Run all tests (not recommended)
+#   tox -- -m "not systest"               # Run all unit tests
+#   tox -- -m "systest and not unstable"  # Run stable system tests
+#   tox -- -m "unstable"                  # Run unstable system tests
 
 [tox]
 envlist = py3
@@ -14,4 +14,4 @@ commands = pytest {posargs}
 [pytest]
 markers =
     systest: mark a system test, i.e., virtual machines will be run.
-    longtest: mark a test that usually runs longer than ten minutes.
+    unstable: mark a system test that does not (yet) reliably work.


### PR DESCRIPTION
The logging and NTP system tests are not stable at the moment, which should be transparent. The logging test is not even long in case it works, so calling them "unstable" seems more suitable.