### PR TITLE
Increase Attacker timeout value from 120 to 180 minutes

### DIFF
--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Build Attacker
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_attacker runner
         

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Build Attacker
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_attacker runner
         


### PR DESCRIPTION
After clearing the cache, the attacker-build will run into a timeout on runner machines with slower internet connection (due to the size of the Kali-iso).

This change fixes that by increasing the respective timeout values.