### PR TITLE
Install dosfstools on attacker

### DIFF
--- a/provisioning/ansible/attacker_playbook.yml
+++ b/provisioning/ansible/attacker_playbook.yml
@@ -31,3 +31,4 @@
     - spearphishing
     - generate_malware
     - ssh_config
+    - dosfstools

--- a/provisioning/ansible/roles/dosfstools/tasks/main.yml
+++ b/provisioning/ansible/roles/dosfstools/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+
+# dosfstools provide the mkfs.fat command, which is used by infect_flashdrive_exe
+- name: Install dosfstools
+  apt:
+    name: dosfstools
+    update_cache: yes
+    state: present


### PR DESCRIPTION
Required for mkfs.fat command, which is used by infect_flashdrive_exe