### PR TITLE
Increase RAM on Company Router, decrease on Log Server

### DIFF
--- a/provisioning/packer/companyrouter.json
+++ b/provisioning/packer/companyrouter.json
@@ -9,6 +9,7 @@
   },
   "builders": [
     {
+      "memory": "1536",
       "name": "Company-Router (IP-Fire)",
       "type": "virtualbox-iso",
       "guest_os_type": "Linux_64",

--- a/provisioning/packer/logserver.json
+++ b/provisioning/packer/logserver.json
@@ -54,7 +54,7 @@
         "http://old-releases.ubuntu.com/releases/16.04.5/ubuntu-16.04.6-server-amd64.iso"
       ],
       "keep_registered": "true",
-      "memory": "4096",
+      "memory": "3072",
       "output_directory": "{{user `vm_output`}}",
       "pause_before_connecting": "1m",
       "shutdown_command": "echo 'packer' | sudo -S shutdown -P now",


### PR DESCRIPTION
Company Router now has 1,5 GB, Log Server has 3 GB RAM.
The new values are the same as used for the paper evaluation.
Before, the Company Router only had 0,5 GB RAM, which resulted
in occasional Suricata crashes and therefore unstable measurements.