### PR TITLE
Increase job timeout values

### DIFF
--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Build Client
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_client runner
         

--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -27,6 +27,7 @@ jobs:
   build-machines:
     runs-on: [self-hosted, linux]
     needs: [prepare-environment]
+    timeout-minutes: 480
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -26,6 +26,7 @@ jobs:
   build-machines:
     runs-on: [self-hosted, linux]
     needs: [prepare-environment]
+    timeout-minutes: 480
     steps:
       - uses: actions/checkout@v2
       
@@ -77,7 +78,7 @@ jobs:
       - name: Build Client
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 120
+          timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_client runner
         


### PR DESCRIPTION
Github automatically cancels any job after 6 hours unless told not to. Setting the timeout value for our build-job to 8 hours should fix our random timeouts after the cache has been deleted.

Also increased Client build timeout from 2 to 3 hours.