### PR TITLE
Runner bugfix

### DIFF
--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -103,15 +103,12 @@ jobs:
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
-      - name: Ensure all machines are powered off
-        run: ./tools/cleanup_failed_session
-      
-      - name: Run stable system tests
+      - name: Ensure all machines are powered off and run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: tox -- -m "systest and not unstable"
+          command: ./tools/cleanup_failed_session && tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 30
+          timeout_minutes: 60
           max_attempts: 3
           command: tox -- -m "systest and not unstable"
    

--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -103,12 +103,15 @@ jobs:
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
-      - name: Ensure all machines are powered off and run stable system tests
+      - name: Ensure all machines are powered off
+        run: ./tools/cleanup_failed_session
+      
+      - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./tools/cleanup_failed_session && tox -- -m "systest and not unstable"
+          command: tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -101,12 +101,15 @@ jobs:
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
-      - name: Ensure all machines are powered off and run stable system tests
+      - name: Ensure all machines are powered off
+        run: ./tools/cleanup_failed_session
+      
+      - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: ./tools/cleanup_failed_session && tox -- -m "systest and not unstable"
+          command: tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -101,15 +101,12 @@ jobs:
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
-      - name: Ensure all machines are powered off
-        run: ./tools/cleanup_failed_session
-      
-      - name: Run stable system tests
+      - name: Ensure all machines are powered off and run stable system tests
         uses: nick-invision/retry@v2
         with:
           timeout_minutes: 30
           max_attempts: 3
-          command: tox -- -m "systest and not unstable"
+          command: ./tools/cleanup_failed_session && tox -- -m "systest and not unstable"
    
   delete-machines:
     runs-on: [self-hosted, linux]

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 30
+          timeout_minutes: 60
           max_attempts: 3
           command: tox -- -m "systest and not unstable"
    


### PR DESCRIPTION
Increases the timeout value for the task "Run stable system tests" to prevent the Runner from getting breaking stuff. If the tests ran into the timeout defined by our workflow, the VMs wouldnt shut down properly and all subsequent attempts of that tasks would fail. Simply increasing that timeout should fix that.