### PR TITLE
Fix failing provisioning

### DIFF
--- a/provisioning/ansible/roles/auditbeat/tasks/add_auditbeat_apt_repository.yml
+++ b/provisioning/ansible/roles/auditbeat/tasks/add_auditbeat_apt_repository.yml
@@ -1,8 +1,11 @@
 ---
 - name: Add Elastic apt key
   apt_key:
-    url: "https://packages.elastic.co/GPG-KEY-elasticsearch"
+    url: "https://artifacts.elastic.co/GPG-KEY-elasticsearch"
     state: present
+  retries: 2
+  register: result
+  until: result is succeeded
 
 - name: Add Elastic repo
   apt_repository:

--- a/provisioning/ansible/roles/elasticsearch/tasks/main.yml
+++ b/provisioning/ansible/roles/elasticsearch/tasks/main.yml
@@ -5,8 +5,11 @@
 
 - name: Add Elastic apt key
   apt_key:
-    url: "https://packages.elastic.co/GPG-KEY-elasticsearch"
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
+  retries: 2
+  register: result
+  until: result is succeeded
 
 - name: Add Elastic repo
   apt_repository:

--- a/provisioning/ansible/roles/packetbeat/tasks/main.yml
+++ b/provisioning/ansible/roles/packetbeat/tasks/main.yml
@@ -2,6 +2,9 @@
   get_url:
     url: "https://artifacts.elastic.co/downloads/beats/packetbeat/{{ packetbeat_name }}.tar.gz"
     dest: "/tmp"
+  retries: 2
+  register: result
+  until: result is succeeded
     
 - name: Unpack packetbeat files to /opt/
   unarchive:

--- a/provisioning/packer/attacker.json
+++ b/provisioning/packer/attacker.json
@@ -4,13 +4,13 @@
     {
       "boot_command": [
         "<wait><esc><wait>",
-        "/install.amd/vmlinuz ", "<wait5s>",
-        "initrd=/install.amd/initrd.gz ", "<wait5s>",
-        "auto-install/enable=true ", "<wait5s>",
-        "debconf/priority=critical ", "<wait5s>",
+        "/install.amd/vmlinuz ",
+        "initrd=/install.amd/initrd.gz ",
+        "auto-install/enable=true ",
+        "debconf/priority=critical ",
         "preseed/url=http://{{user `host_ip_addr`}}:{{.HTTPPort}}/attacker_preseed.cfg ", "<wait5s>",
-        "netcfg/choose_interface=enp0s8 ", "<wait5s>",
-        "netcfg/disable_autoconfig=true ", "<wait5s>",
+        "netcfg/choose_interface=enp0s8 ",
+        "netcfg/disable_autoconfig=true ",
         "netcfg/get_ipaddress=192.168.56.31 ",
         "netcfg/get_netmask=255.255.255.0 ",
         "netcfg/get_gateway=192.168.56.1 ",
@@ -21,7 +21,7 @@
         "console-setup/ask_detect=false ",
         "<enter>"
       ],
-      "boot_keygroup_interval": "500ms",
+      "boot_keygroup_interval": "5000ms",
       "boot_wait": "5s",
       "disk_size": "16384",
       "export_opts": [


### PR DESCRIPTION
It seems like either the Internet or Company Router is unable to handle HTTP requests belonging to `artifacts.elastic.co` the first time they appear (subsequent attempts succeed). Adding the `retry`-keyword to ansible roles affected by this should provide a temporary fix while we look into why this fails in the first place.

Roles changed:
- auditbeat
- elasticsearch
- packetbeat