### PR TITLE
Improve timeout error handling

### DIFF
--- a/src/attacks/attack.py
+++ b/src/attacks/attack.py
@@ -73,8 +73,10 @@ class Attack:
     def wrap_ssh_exceptions(self):
         try:
             yield
-        except (paramiko.SSHException, socket.error, socket.timeout) as e:
-            raise AttackException(e)
+        except socket.timeout:
+            print(f"Timeout after {self.ssh_client.channel_timeout}s")
+        except (paramiko.SSHException, socket.error) as err:
+            raise AttackException(err) from err
 
     def exec_command_on_target(self, command):
         self.exec_commands_on_target([command])

--- a/src/attacks/tests/test_attack.py
+++ b/src/attacks/tests/test_attack.py
@@ -17,6 +17,8 @@
 
 
 import pytest
+import socket
+from unittest.mock import patch
 
 from attacks.attack import AttackInfo, AttackOptions, Attack
 
@@ -58,6 +60,14 @@ class TestAttack:
         msg = "Hello World"
         attack.print(msg=msg)
         assert p.last_msg == msg
+
+    def test_timeout_exception(self, capfd):
+        attack = Attack()
+        with attack.wrap_ssh_exceptions():
+            raise socket.timeout
+        out = capfd.readouterr()[0].split("\n")
+        assert out[0] == "Timeout after 300s"
+        assert not out[1]
 
 
 class TestAttackInfo:


### PR DESCRIPTION
This adds a simple timeout message to the console, if a timeout occurs.
E.g.:

```sh
[…]
Timeout after 300s
[…]
```