### PR TITLE
Add user-friendly boolean handling

### DIFF
--- a/src/attacks/tests/test_util.py
+++ b/src/attacks/tests/test_util.py
@@ -1,0 +1,40 @@
+import pytest
+
+from attacks.util import print_error, print_warning, str_to_bool
+
+
+def test_print_error(capfd):
+    print_error("MSG")
+    out, err = capfd.readouterr()
+    assert out == "\x1b[91mError: MSG\x1b[0m\n"
+    assert not err
+
+
+def test_print_warning(capfd):
+    print_warning("MSG")
+    out, err = capfd.readouterr()
+    assert out == "\x1b[93mWarning: MSG\x1b[0m\n"
+    assert not err
+
+
+@pytest.mark.parametrize("val_in", ("y", "yes", "t", "true", "on", "1"))
+def test_str_to_bool_true(val_in):
+    assert str_to_bool(val_in) is True
+
+
+@pytest.mark.parametrize("val_in", ("n", "no", "f", "false", "off", "0"))
+def test_str_to_bool_false(val_in):
+    assert not str_to_bool(val_in)
+
+
+def test_str_to_bool_default(capfd):
+    assert not str_to_bool("NOT_VALID")
+    assert str_to_bool("NOT_VALID", default=True) is True
+
+    out, err = capfd.readouterr()
+    out = out.split("\n")
+    assert out[0] == "\x1b[91mError: No valid Boolean value: not_valid\x1b[0m"
+    assert out[1] == "\x1b[93mWarning: Default to: False\x1b[0m"
+    assert out[2] == "\x1b[91mError: No valid Boolean value: not_valid\x1b[0m"
+    assert out[3] == "\x1b[93mWarning: Default to: True\x1b[0m"
+    assert not err

--- a/src/attacks/util.py
+++ b/src/attacks/util.py
@@ -1,0 +1,30 @@
+from typing import Union
+
+
+class Colors:
+    lblue: str = "\x1b[94m"
+    lgreen: str = "\x1b[92m"
+    lred: str = "\x1b[91m"
+    lyellow: str = "\x1b[93m"
+    endc: str = "\x1b[0m"
+    bold: str = "\x1b[1m"
+
+
+def print_error(msg: str) -> None:
+    print(f"{Colors.lred}Error: {msg}{Colors.endc}")
+
+
+def print_warning(msg: str) -> None:
+    print(f"{Colors.lyellow}Warning: {msg}{Colors.endc}")
+
+
+def str_to_bool(val: Union[str, bool], default: bool = False) -> bool:
+    val = str(val).lower()
+    if val in {"y", "yes", "t", "true", "on", "1"}:
+        return True
+    elif val in {"n", "no", "f", "false", "off", "0"}:
+        return False
+
+    print_error(f"No valid Boolean value: {val}")
+    print_warning(f"Default to: {default}")
+    return default


### PR DESCRIPTION
This adds a util file which can be used for helper functions.
In this case, it first contains some functions to output error or warning messages.
It also provides a function to make parsing boolean values more user-friendly by allowing different variants to be interpreted as true or false. Like “y” or “yes” for true and “n” or “no” for false.

Even though none of your existing attacks provide boolean values as parameters at the moment, I plan to contribute several attacks in the future that can use this functionality.