### PR TITLE
dev hotfix

### DIFF
--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 60
           max_attempts: 5
           on_retry_command: ./tools/cleanup_failed_session
           command: tox -- -m "systest and not unstable"

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Run stable system tests
         uses: nick-invision/retry@v2
         with:
-          timeout_minutes: 45
+          timeout_minutes: 60
           max_attempts: 5
           on_retry_command: ./tools/cleanup_failed_session
           command: tox -- -m "systest and not unstable"

--- a/src/attacks/attack.py
+++ b/src/attacks/attack.py
@@ -73,15 +73,18 @@ class Attack:
 
     @contextmanager
     def wrap_ssh_exceptions(self):
+        # SIGINT = signal sent when pressing ctrl+C
         signal(SIGINT, self.handle_interrupt)
         try:
             yield
-        except socket.timeout:
+        except socket.timeout as err:
             print(f"Timeout after {self.ssh_client.channel_timeout}s")
             self.handle_interrupt()
-        except (paramiko.SSHException, socket.error, OSError) as err:
-            self.handle_interrupt()
             raise AttackException(err) from err
+        except (paramiko.SSHException, socket.error) as err:
+            raise AttackException(err) from err
+            # this code is unreachable
+            self.handle_interrupt()
         finally:
             signal(SIGINT, default_int_handler)
 

--- a/src/attacks/attack.py
+++ b/src/attacks/attack.py
@@ -79,7 +79,7 @@ class Attack:
         except socket.timeout:
             print(f"Timeout after {self.ssh_client.channel_timeout}s")
             self.handle_interrupt()
-        except (paramiko.SSHException, socket.error) as err:
+        except (paramiko.SSHException, socket.error, OSError) as err:
             self.handle_interrupt()
             raise AttackException(err) from err
         finally:

--- a/src/attacks/attack_execute_malware.py
+++ b/src/attacks/attack_execute_malware.py
@@ -51,7 +51,9 @@ class ExecuteMalwareAttack(Attack):
         client_nr = self.options.rhost[-2:].lstrip("0")
         client_name = "client" + client_nr
 
-        cmd = (f"schtasks /create /sc once /st 23:59 /tn {random_tag} "
+        cmd = (f"if exist {file} "
+               f"(schtasks /create /sc once /st 23:59 /tn {random_tag} "
                f"/tr \"{file}\" /ru BREACH\\{client_name} && "
-               f"schtasks /run /tn {random_tag}")
+               f"schtasks /run /tn {random_tag}) "
+               f"else (echo Unable to locate {file})")
         return cmd

--- a/src/attacks/attackconsole.py
+++ b/src/attacks/attackconsole.py
@@ -168,6 +168,8 @@ class SubAttackConsole(Cmd):
             print("*** Exception: {e}".format(e=e))
             log_dict.update(event="attack_failed", failed_with=str(e).replace("\n", " "))
             self.logger.info("Attack failed", log_dict=log_dict)
+        except KeyboardInterrupt:
+            self.attack.handle_interrupt()
         else:
             log_dict.update(event="attack_succeeded")
             self.logger.info("Attack succeeded", log_dict=log_dict)

--- a/src/attacks/tests/test_attack.py
+++ b/src/attacks/tests/test_attack.py
@@ -18,9 +18,9 @@
 
 import pytest
 import socket
-from unittest.mock import patch, Mock, PropertyMock
+from unittest.mock import patch, Mock
 
-from attacks.attack import AttackInfo, AttackOptions, Attack
+from attacks.attack import AttackInfo, AttackOptions, Attack, AttackException
 
 
 class PrinterSpy:
@@ -61,11 +61,11 @@ class TestAttack:
         attack.print(msg=msg)
         assert p.last_msg == msg
 
-    @patch("attacks.attack.Attack.handle_interrupt")
-    def test_timeout_exception(self, _mock, capfd):
+    def test_timeout_exception(self, capfd):
         attack = Attack()
-        with attack.wrap_ssh_exceptions():
-            raise socket.timeout
+        with pytest.raises(AttackException):
+            with attack.wrap_ssh_exceptions():
+                raise socket.timeout
         out = capfd.readouterr()[0].split("\n")
         assert out[0] == "Timeout after 300s"
         assert not out[1]


### PR DESCRIPTION
- Increase total systest timeout value to 60 minutes (from 45)
    - should prevent cases where a pipeline runs into a timeout without actually being stuck somewhere (e.g. when a lot of tests fail, which just takes a while)
    - the former case was not desirable because it prevents any error output from being printed
- Modify `misc_execute_malware` to properly catch failures
    - previously, the attack only checked if the schedules task was created successfully, which is always the case, no matter the command contained in that scheduled task
    - now checks for the existence of the malicious file beforehand
- Move usage of `handle_interrupt` to attackconsole (aka only used for manual interaction)
    - Fixes buggy SIGINT interaction with tox tests
    - Prevents cases where a broken socket is used during testing without wrapping, leading to uncatched exceptions
    - Modified unit tests accordingly