### PR TITLE
Fix incorrect time on client

### DIFF
--- a/provisioning/ansible/roles/configure_win10_client/tasks/install_ssh_server.yml
+++ b/provisioning/ansible/roles/configure_win10_client/tasks/install_ssh_server.yml
@@ -23,17 +23,17 @@
 
 - name: SSH - Copy installation script
   win_template:
-    src: "{{ role_path }}/templates/install-openssh.ps1.j2"
+    src: "../templates/install-openssh.ps1.j2"
     dest: "C:\\install-openssh.ps1"
   when: not private_key.stat.exists
 
 - name: SSH - Run installation script
-  raw: "C:\\install-openssh.ps1"
+  win_shell: "C:\\install-openssh.ps1"
   when: not private_key.stat.exists
 
 - name: SSH - Deploy ssh server configuration
   win_template:
-    src: "{{ role_path }}/templates/sshd_config.j2"
+    src: "../templates/sshd_config.j2"
     dest: "{{ openssh_extract_dir }}\\{{ openssh_archive_name }}\\sshd_config"
   notify:
     - restart sshd

--- a/provisioning/ansible/roles/configure_win10_client/tasks/main.yml
+++ b/provisioning/ansible/roles/configure_win10_client/tasks/main.yml
@@ -1,4 +1,5 @@
 - include: setup_user.yml
+- include: set_timezone.yml
 - include: add_exclusion_folder.yml
 - include: disable_firewall.yml
 - include: disable_screen_lock.yml

--- a/provisioning/ansible/roles/configure_win10_client/tasks/set_timezone.yml
+++ b/provisioning/ansible/roles/configure_win10_client/tasks/set_timezone.yml
@@ -1,0 +1,4 @@
+- name: Set time zone to CET and disable daylight saving time
+  community.windows.win_timezone:
+    timezone: Central European Standard Time_dstoff
+    # "_dstoff" disables daylight saving time


### PR DESCRIPTION
Sets timezone on client to Central European Standard time with daylight savings time permanently  _disabled_, which fixes the client lagging behind by one hour.

We might need to revisit this once we switch to summer time again, if I recall correctly our Linux machines just copy the timezone of the host - which would again cause the client to be off by an hour. If this bug reoccurs, we should also set all other machines to a fixed timezone, i.e. the one the client now uses.

For now, this solves the issue.