### PR TITLE
Update dead ansible script link

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -50,10 +50,9 @@ The following packages are required for the tasks executed by the runner:
     sudo apt install -y build-essential libssl-dev libffi-dev python3-dev
     ```
 
-- Python pip and virtual environments
+- Python pip, virtual environments and tox
     ```sh
-    sudo apt install -y python3-pip
-    sudo apt install -y python3-venv
+    sudo apt install -y python3-pip python3-venv tox
     ```
     
 - (optional) cowsay + fortunes

--- a/provisioning/ansible/roles/spark/tasks/main.yml
+++ b/provisioning/ansible/roles/spark/tasks/main.yml
@@ -7,6 +7,8 @@
   get_url:
     url: "{{ spark_url }}"
     dest: "{{ spark_bin_tmp_archive }}"
+    # This particular task times out very often, this should hopefully alleviate that (default was 10)
+    timeout: 60
 
 - name: "Extract Spark Tarball and move Spark to install directory {{ spark_dir }}"
   unarchive:  

--- a/provisioning/packer/client.json
+++ b/provisioning/packer/client.json
@@ -115,7 +115,7 @@
   ],
   "variables": {
     "floppy_files_path": "./floppy_files/",
-    "iso_checksum": "823c3cb59ff0fd43272f12bb2e3a089d",
+    "iso_checksum": "68c70d7ade5e9ab8510876c1f4bee58a",
     "iso_url": "/usr/share/runner-dependencies/windows_isos/Win10_21H2_English_x64.iso",
     "vm_description": "SOCBED: Client",
     "vm_version": "fresh",

--- a/provisioning/packer/client.json
+++ b/provisioning/packer/client.json
@@ -91,7 +91,7 @@
     },    
     {
       "inline": [
-        "iwr https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -UseBasicParsing | iex"
+        "iwr https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1 -UseBasicParsing | iex"
       ],
       "type": "powershell"
     },


### PR DESCRIPTION
### Most important change:
A script used by our `client.json` packer template was dead due to ansible moving their example scripts (among other things) to a separate repository. The full issue regarding this change can be found [here](https://github.com/ansible/ansible/pull/81011).

Will mark this PR as ready as soon as the [corresponding pipeline](https://github.com/fkie-cad/socbed/actions/runs/5785938185) has passed.

### Other
Apart from this, there are some other minor changes:
- Use newer Windows version (including updated hashes)
- Add tox to CI requirement
- Increase timeout for ansible `spark` task