### PR TITLE
Update GitHub action versions

### DIFF
--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -9,7 +9,7 @@ jobs:
   delete-cache:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Delete cached iso files
         run: rm -rf /usr/share/runner-dependencies/packer_cache/*

--- a/.github/workflows/socbed-systemtest-dev.yml
+++ b/.github/workflows/socbed-systemtest-dev.yml
@@ -8,7 +8,7 @@ jobs:
   prepare-environment:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: dev
       
@@ -29,7 +29,7 @@ jobs:
     needs: [prepare-environment]
     timeout-minutes: 480
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: dev
       
@@ -37,56 +37,56 @@ jobs:
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
       - name: Build Internet Router
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_internetrouter runner
       
       - name: Build Company Router
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_companyrouter runner
         
       - name: Build Attacker
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_attacker runner
         
       - name: Build Log Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 120
           max_attempts: 3
           command: ./tools/build_logserver runner
         
       - name: Build Internal Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_internalserver runner
         
       - name: Build DMZ Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_dmzserver runner
         
       - name: Build Client
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_client runner
         
       - name: Run logging setup
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, linux]
     needs: [prepare-environment, build-machines]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: dev
       
@@ -107,7 +107,7 @@ jobs:
         run: ./tools/cleanup_failed_session
       
       - name: Run stable system tests
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 5
@@ -119,7 +119,7 @@ jobs:
     if: always()
     needs: [prepare-environment, build-machines, test-machines]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: dev
       

--- a/.github/workflows/socbed-systemtest.yml
+++ b/.github/workflows/socbed-systemtest.yml
@@ -9,7 +9,7 @@ jobs:
   prepare-environment:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Create virtual environment
         run: python3 -m venv /usr/share/runner-dependencies/socbed_env
@@ -31,62 +31,62 @@ jobs:
     needs: [prepare-environment]
     timeout-minutes: 480
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
       
       - name: Build Internet Router
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_internetrouter runner
       
       - name: Build Company Router
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_companyrouter runner
         
       - name: Build Attacker
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_attacker runner
         
       - name: Build Log Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 120
           max_attempts: 3
           command: ./tools/build_logserver runner
         
       - name: Build Internal Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_internalserver runner
         
       - name: Build DMZ Server
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
           command: ./tools/build_dmzserver runner
         
       - name: Build Client
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 180
           max_attempts: 3
           command: ./tools/build_client runner
         
       - name: Run logging setup
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 3
@@ -96,7 +96,7 @@ jobs:
     runs-on: [self-hosted, linux]
     needs: [prepare-environment, build-machines]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Activate virtual environment
         run: source /usr/share/runner-dependencies/socbed_env/bin/activate
@@ -105,7 +105,7 @@ jobs:
         run: ./tools/cleanup_failed_session
       
       - name: Run stable system tests
-        uses: nick-invision/retry@v2
+        uses: nick-invision/retry@v3
         with:
           timeout_minutes: 60
           max_attempts: 5
@@ -117,7 +117,7 @@ jobs:
     if: always()
     needs: [prepare-environment, build-machines, test-machines]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       - name: Delete created VMs
         run: ./tools/delete_vms

--- a/.github/workflows/socbed-unittest.yml
+++ b/.github/workflows/socbed-unittest.yml
@@ -8,6 +8,6 @@ jobs:
   tox-unit-test:
     runs-on: [self-hosted, linux]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: tox -- -m "not systest"
 


### PR DESCRIPTION
Upraded checkout@v3 to v4 and retry@v2 to v3

GitHub actions is transitioning from Node 16 to Node 20 ([link](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)). Since the former will no longer be supported in the near future, any actions using Node 16 must be upgraded to instead use Node 20 - this PR does just that.