### PR TITLE
Replace smtpd with aiosmtpd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ __pycache__/
 ### Cache ###
 .cache/*
 
-# DS_STORE 
+# DS_STORE
 .DS_STORE
 
 ### PyCharm ###

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pywinrm==0.4.1
 selenium==4.3.0
 tox==3.7.0
 veryprettytable==0.8.1
+asyncio==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,12 @@
 ansible==5.1.0
 colorama==0.4.1
 paramiko==2.11.0
-pytest==5.2.0
+pytest==8.3.3
 pyvmomi==6.7.1.2018.12
 pywinrm==0.4.1
 selenium==4.3.0
 tox==3.7.0
 veryprettytable==0.8.1
 asyncio==3.4.3
+setuptools~=74.1.2
+aiosmtpd~=1.4.6

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,10 @@ setup(
         "paramiko",
         "pyvmomi",
         "veryprettytable",
-        "selenium"
+        "selenium",
+        "aiosmtpd",
+        "pytest-asyncio",
+        "pytest-mock"
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         "selenium",
         "aiosmtpd",
         "pytest-asyncio",
-        "pytest-mock"
+        "pytest-mock",
+        "pytest-print"
     ],
     entry_points={
         'console_scripts': [

--- a/src/attacks/tests/test_attack_sqlmap.py
+++ b/src/attacks/tests/test_attack_sqlmap.py
@@ -16,7 +16,7 @@
 # along with SOCBED. If not, see <http://www.gnu.org/licenses/>.
 
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -31,10 +31,15 @@ def attack():
 
 
 class TestSQLMapAttack:
+
+
     def test_sqlmap_command(self, attack: SQLMapAttack):
-        assert attack._sqlmap_command() == (
-            "export COLUMNS=80; echo \"http://172.18.0.2/dvwa/vulnerabilities/sqli/?id=&Submit=Submit\" | "
-            "sqlmap --purge --batch --dump")
+        with patch("attacks.attack_sqlmap.get_terminal_size") as mock_get_terminal_size:
+            # on larger monitors, this value will be != 80
+            mock_get_terminal_size.return_value.columns = 80
+            assert attack._sqlmap_command() == (
+                "export COLUMNS=80; echo \"http://172.18.0.2/dvwa/vulnerabilities/sqli/?id=&Submit=Submit\" | "
+                "sqlmap --purge --batch --dump")
 
     def test_raise_exception_bad_output(self, attack: SQLMapAttack):
         attack.exec_commands_on_target = lambda _: attack.printer.print("Bad output")

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,4 @@ markers =
     systest: mark a system test, i.e., virtual machines will be run.
     unstable: mark a system test that does not (yet) reliably work.
     longtest: mark a unit test that takes longer than 10 seconds.
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
Replaces the as of Python 3.12 fully deprecated `smtpd` module with aiosmptd and update tests accordingly.

Also updates a small bug in one of our sqlmap_attack tests: On very large monitors (>27"), the terminal size will be different, leading to unexpected failures. I've patched the relevant function to return a fixed value instead.

Note that our runner is currently down. I will bring it back up in the very near future (meaning tomorrow, 13.09).