### PR TITLE
Source frequently updated packages from archive repositories

### DIFF
--- a/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
+++ b/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
@@ -4,17 +4,27 @@
 # Additionally, creates a logrotate config file for logs
 #
 
-- name: Ensure compatible version of binutils
-  apt:
-    name: binutils=2.43.1-5
-    state: present
-    update_cache: yes
-    
+- name: Add Kali Linux archive repository manually
+  copy:
+    dest: /etc/apt/sources.list.d/kali-archive.list
+    content: "deb [trusted=yes] http://old.kali.org/kali 2024.4 main contrib non-free"
+
+- name: Update apt cache ignoring signature verification
+  shell: apt-get update -o Acquire::AllowInsecureRepositories=true -o Acquire::AllowDowngradeToInsecureRepositories=true
+
 - name: Install aiosmtpd (requirement) globally
   apt:
     name: python3-aiosmtpd=1.4.6-3
-    update_cache: yes
     state: present
+    allow_downgrade: yes
+
+- name: Remove Kali Linux archive repository after installing required packages
+  apt_repository:
+    repo: "deb http://old.kali.org/kali 2024.4 main contrib non-free"
+    state: absent
+
+- name: Update apt cache after removing repository
+  shell: apt-get update
 
 - name: "Create script directory {{ script_dir }}"
   file:

--- a/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
+++ b/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
@@ -12,7 +12,7 @@
     
 - name: Install aiosmtpd (requirement) globally
   apt:
-    name: python3-aiosmtpd=1.4.6-1
+    name: python3-aiosmtpd=1.4.6
     update_cache: yes
     state: present
 

--- a/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
+++ b/provisioning/ansible/roles/external_mail_handler/tasks/main.yml
@@ -12,7 +12,7 @@
     
 - name: Install aiosmtpd (requirement) globally
   apt:
-    name: python3-aiosmtpd=1.4.6
+    name: python3-aiosmtpd=1.4.6-3
     update_cache: yes
     state: present
 


### PR DESCRIPTION
I'm not sure why, but older version of this are no longer available when a new one releases. If this happens again, I'll probably add an archive repo to apt so that we can source aiosmtpd from there with a fixed version. In any case, with this small version change the runner is working again.