### PR TITLE
Fix issue preventing auditbeat data from reaching the log server

### DIFF
--- a/provisioning/ansible/companyrouter_playbook.yml
+++ b/provisioning/ansible/companyrouter_playbook.yml
@@ -8,3 +8,4 @@
     - rsyslog_install_ipfire
     - rsyslog_ISO8601
     - rsyslog_forwarding
+    - auditbeat_forwarding

--- a/provisioning/ansible/roles/auditbeat_forwarding/tasks/main.yml
+++ b/provisioning/ansible/roles/auditbeat_forwarding/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: Configure firewall to allow auditbeat on the DMZ (ORANGE) to communicate with the logserver (GREEN)
+  lineinfile:
+    path: /var/ipfire/firewall/config
+    line: "8,ACCEPT,FORWARDFW,ON,std_net_src,ORANGE,std_net_tgt,GREEN,,TCP,,,ON,,,TGT_PORT,9200,Allow elasticsearch log TCP on port 9200 from ORANGE to GREEN,,,,,,,,,,00:00,00:00,,AUTO,,dnat,,,,,second"
+    state: present

--- a/src/systests/test_logging.py
+++ b/src/systests/test_logging.py
@@ -34,7 +34,7 @@ from vmcontrol.sessionhandler import SessionHandler
 from vmcontrol.vmmcontroller import VBoxController
 
 MAX_RUNTIME = 10 * 60  # Ten minutes
-pytestmark = [pytest.mark.systest, pytest.mark.tmp_logging]
+pytestmark = [pytest.mark.systest]
 
 
 @pytest.fixture(scope="module")

--- a/src/systests/test_logging.py
+++ b/src/systests/test_logging.py
@@ -34,7 +34,7 @@ from vmcontrol.sessionhandler import SessionHandler
 from vmcontrol.vmmcontroller import VBoxController
 
 MAX_RUNTIME = 10 * 60  # Ten minutes
-pytestmark = [pytest.mark.systest]
+pytestmark = [pytest.mark.systest, pytest.mark.tmp_logging]
 
 
 @pytest.fixture(scope="module")
@@ -59,22 +59,33 @@ class TestLogging:
         SSHTargets.log_server,
         SSHTargets.internal_server,
         SSHTargets.dmz_server,
-        SSHTargets.client_1]
+        SSHTargets.client_1,
+    ]
     forwarding_machines = [
         SSHTargets.company_router,
         SSHTargets.internal_server,
         SSHTargets.dmz_server,
-        SSHTargets.client_1]
+        SSHTargets.client_1,
+    ]
     windows_machines = [
-        SSHTargets.client_1]
+        SSHTargets.client_1,
+    ]
     packetbeat_machines = [
-        SSHTargets.company_router]
+        SSHTargets.company_router,
+    ]
+    auditbeat_machines = [
+        SSHTargets.internal_server,
+        SSHTargets.dmz_server,
+    ]
     log_server = SSHTargets.log_server
 
     @pytest.mark.parametrize("machine", machines, ids=lambda m: m.name)
     def test_local_and_remote_logging(self, machine, timeout_counter):
         elasticsearch_query_values = namedtuple(
-            "elasticsearch_query_values", "token search_keyword timestamp_key")
+            "elasticsearch_query_values",
+            "token search_keyword timestamp_key",
+        )
+
         if machine in self.windows_machines:
             es_query = elasticsearch_query_values(self.unique_token(), "message", "@timestamp")
             self.generate_windows_log(machine, es_query.token, timeout_counter)
@@ -82,18 +93,23 @@ class TestLogging:
             es_query = elasticsearch_query_values(self.unique_token(), "message", "timestamp8601")
             self.generate_linux_log(machine, es_query.token, timeout_counter)
             self.check_local_log_format(machine, es_query.token, timeout_counter)
+
         if machine in self.forwarding_machines:
             self.check_remote_log_format(es_query, timeout_counter)
         if machine in self.packetbeat_machines:
             es_query = elasticsearch_query_values(self.unique_token(), "resource", "@timestamp")
             self.generate_linux_packet_log(machine, es_query.token, timeout_counter)
             self.check_remote_log_format(es_query, timeout_counter)
+        if machine in self.auditbeat_machines:
+            es_query = elasticsearch_query_values(self.unique_token(), "process.args", "@timestamp")
+            self.generate_auditbeat_log(machine, es_query.token, timeout_counter)
+            self.check_remote_log_format(es_query, timeout_counter)
 
     def unique_token(self):
         return str(uuid.uuid4()).replace("-", "")
 
     def generate_windows_log(self, machine, token, timeout_counter):
-        command = f"powershell -command \"echo {token}\""
+        command = f'powershell -command "echo {token}"'
         self.exec_command_and_get_output_list(machine, command, timeout_counter)
 
     def generate_linux_log(self, machine, token, timeout_counter):
@@ -104,19 +120,25 @@ class TestLogging:
         command = f"ping {token}"
         self.exec_command_and_get_output_list(machine, command, timeout_counter)
 
+    def generate_auditbeat_log(self, machine, token, timeout_counter):
+        command = f"auditbeat test output {token}"
+        self.exec_command_and_get_output_list(machine, command, timeout_counter)
+
     def check_local_log_format(self, machine, token, timeout_counter):
         command = f"grep --text {token} /var/log/syslog"
         try_until_counter_reached(
             lambda: self.exec_command_and_get_output_list(machine, command, timeout_counter),
             timeout_counter,
-            assertion_func=lambda x: self.is_iso8601_timestamp(x[0].split()[0]))
+            assertion_func=lambda x: self.is_iso8601_timestamp(x[0].split()[0]),
+        )
 
     def check_remote_log_format(self, es_query, timeout_counter):
         try_until_counter_reached(
             lambda: self.query_elasticsearch(es_query),
             timeout_counter,
             exception=(IndexError, TimeoutError, ConnectionRefusedError, CannotSendRequest),
-            assertion_func=lambda x: self.check_elasticsearch_response(x, es_query))
+            assertion_func=lambda x: self.check_elasticsearch_response(x, es_query),
+        )
 
     def exec_command_and_get_output_list(self, machine, command, timeout_counter):
         ssh_client = BREACHSSHClient(target=machine)
@@ -124,40 +146,29 @@ class TestLogging:
         try_until_counter_reached(
             lambda: ssh_client.exec_command_on_target(command, list_printer),
             timeout_counter,
-            exception=(TimeoutError, ConnectionResetError, SSHException, socket.error))
+            exception=(TimeoutError, ConnectionResetError, SSHException, socket.error),
+        )
         return list_printer.printed
 
     def is_iso8601_timestamp(self, timestamp):
-        iso8601_a = re.compile(
-            r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d\d\d\d[+-]\d\d:\d\d")
-        iso8601_b = re.compile(
-            r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ")
+        iso8601_a = re.compile(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\d\d\d\d[+-]\d\d:\d\d")
+        iso8601_b = re.compile(r"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\d.\d\d\dZ")
         return (iso8601_a.match(timestamp) is not None) or (iso8601_b.match(timestamp) is not None)
 
     def test_is_iso8601_timestamp(self):
-        valid_timestamps = [
-            "2017-06-01T15:45:15.495964+02:00"
-            "2021-02-13T05:50:01.109Z"]
-        invalid_timestamps = [
-            "May 31 16:03:00",
-            "May",
-            ""]
-        assert all(
-            self.is_iso8601_timestamp(valid_timestamp)
-            for valid_timestamp in valid_timestamps)
-        assert not any(
-            self.is_iso8601_timestamp(invalid_timestamp)
-            for invalid_timestamp in invalid_timestamps)
+        valid_timestamps = ["2017-06-01T15:45:15.495964+02:00" "2021-02-13T05:50:01.109Z"]
+        invalid_timestamps = ["May 31 16:03:00", "May", ""]
+        assert all(self.is_iso8601_timestamp(valid_timestamp) for valid_timestamp in valid_timestamps)
+        assert not any(self.is_iso8601_timestamp(invalid_timestamp) for invalid_timestamp in invalid_timestamps)
 
     def query_elasticsearch(self, es_query):
         headers = {"Content-type": "application/json", "Accept": "text/plain"}
         conn = HTTPConnection(f"{self.log_server.hostname}:9200")
         search_query = json.dumps(
-            {"query": {"constant_score": {"filter": {"term": {
-                es_query.search_keyword: es_query.token}}}}})
-        conn.request(
-            method="POST", url="/_search", body=str(search_query), headers=headers)
-        return str(conn.getresponse().read(), 'utf-8')
+            {"query": {"constant_score": {"filter": {"term": {es_query.search_keyword: es_query.token}}}}}
+        )
+        conn.request(method="POST", url="/_search", body=str(search_query), headers=headers)
+        return str(conn.getresponse().read(), "utf-8")
 
     def check_elasticsearch_response(self, response, es_query):
         print(response)


### PR DESCRIPTION
Resolves #102 

Adds the missing firewall rule to allows auditbeat data to reach the log server through the company router.
Also adds a small systest ensuring this is the case (I verified the that the dummy log used for this does not appear in the syslog index).

[Successful pipeline](https://github.com/fkie-cad/socbed/actions/runs/13114735481)