### PR TITLE
Minor fixes

### DIFF
--- a/provisioning/ansible/roles/nodejs/tasks/main.yml
+++ b/provisioning/ansible/roles/nodejs/tasks/main.yml
@@ -1,5 +1,4 @@
 ---
-
 #
 # Install NodeJS
 #
@@ -18,5 +17,4 @@
     name: nodejs
     update_cache: yes
     state: present
-
-
+    allow_unauthenticated: yes

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ paramiko==3.4.1
 pytest==8.3.3
 pyvmomi==8.0.3.0.1
 pywinrm==0.4.1
-selenium==4.3.0
+selenium==3.141.0
 tox==4.18.1
 veryprettytable==0.8.1
 asyncio==3.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ paramiko==3.4.1
 pytest==8.3.3
 pyvmomi==8.0.3.0.1
 pywinrm==0.4.1
-selenium==3.141.0
+selenium==4.39.0
 tox==4.18.1
 veryprettytable==0.8.1
 asyncio==3.4.3

--- a/setup.py
+++ b/setup.py
@@ -30,17 +30,17 @@ setup(
         "paramiko",
         "pyvmomi",
         "veryprettytable",
-        "selenium",
+        "selenium==4.39.0",
         "aiosmtpd",
         "pytest-asyncio",
         "pytest-mock",
-        "pytest-print"
+        "pytest-print",
     ],
     entry_points={
-        'console_scripts': [
-            'attackconsole = attacks.attackconsole:main',
-            'generateattackchains = attacks.generateattackchains:main',
-            'vmconsole = vmcontrol.vmconsole:main'
+        "console_scripts": [
+            "attackconsole = attacks.attackconsole:main",
+            "generateattackchains = attacks.generateattackchains:main",
+            "vmconsole = vmcontrol.vmconsole:main",
         ]
-    }
+    },
 )

--- a/src/userbehavior/setup.py
+++ b/src/userbehavior/setup.py
@@ -5,7 +5,7 @@ setup(
     version="1.0.3",
     packages=find_packages(exclude=["*tests"]),
     package_data={"userbehavior.browsing": ["firefox_extensions/*.xpi"]},
-    install_requires=["selenium==3.141.0"],
+    install_requires=["selenium==4.39.0"],
     entry_points={
         "console_scripts": [
             "userbehavior = userbehavior.run:main",

--- a/src/userbehavior/setup.py
+++ b/src/userbehavior/setup.py
@@ -5,10 +5,10 @@ setup(
     version="1.0.3",
     packages=find_packages(exclude=["*tests"]),
     package_data={"userbehavior.browsing": ["firefox_extensions/*.xpi"]},
-    install_requires=["selenium>=3.0.0"],
+    install_requires=["selenium==4.3.0"],
     entry_points={
-        'console_scripts': [
-            'userbehavior = userbehavior.run:main',
+        "console_scripts": [
+            "userbehavior = userbehavior.run:main",
         ]
-    }
+    },
 )

--- a/src/userbehavior/setup.py
+++ b/src/userbehavior/setup.py
@@ -5,7 +5,7 @@ setup(
     version="1.0.3",
     packages=find_packages(exclude=["*tests"]),
     package_data={"userbehavior.browsing": ["firefox_extensions/*.xpi"]},
-    install_requires=["selenium==4.3.0"],
+    install_requires=["selenium==3.141.0"],
     entry_points={
         "console_scripts": [
             "userbehavior = userbehavior.run:main",


### PR DESCRIPTION
- The Selenium version used by our unit tests wasn't actually fixed
  - The `FirefoxBinary` class has been deprecated in the the [latest release](https://github.com/SeleniumHQ/selenium/blob/trunk/py/CHANGES#L9), which broke our code
  - We could use the newer class instead, but since I don't know if this has any other implications, I opted to use 4.39 instead
- Keys for the version of NodeJS installed by our ansible role are deprecated, so I've set `allow_unauthenticated` to yes
  - Ubuntu 16.04 is kind of old :p

Successful pipeline [here](https://github.com/fkie-cad/socbed/actions/runs/22167524053)